### PR TITLE
feat: Disable password manager autocomplete on forms

### DIFF
--- a/libs/ui/src/form/Input.vue
+++ b/libs/ui/src/form/Input.vue
@@ -5,6 +5,8 @@
         v-model="model"
         :aria-label="id"
         autocomplete="off"
+        data-lpignore="true"
+        data-bwignore="true"
         :type="type"
         :class="[style, { 'pr-7': clearable && model }]"
         class="!w-full"

--- a/libs/ui/src/form/InputNumber.vue
+++ b/libs/ui/src/form/InputNumber.vue
@@ -3,6 +3,8 @@
     <input
       v-model="model"
       autocomplete="off"
+      data-lpignore="true"
+      data-bwignore="true"
       :aria-label="id"
       type="number"
       class="w-full"

--- a/libs/ui/src/form/Textarea.vue
+++ b/libs/ui/src/form/Textarea.vue
@@ -3,6 +3,8 @@
     <textarea
       v-model="model"
       autocomplete="off"
+      data-lpignore="true"
+      data-bwignore="true"
       type="text"
       :aria-label="id"
       class="w-full"

--- a/libs/ui/src/form/select/AutoComplete.vue
+++ b/libs/ui/src/form/select/AutoComplete.vue
@@ -18,6 +18,8 @@
       aria-autocomplete="list"
       aria-haspopup="listbox"
       autocomplete="off"
+      data-lpignore="true"
+      data-bwignore="true"
       autocorrect="off"
       spellcheck="false"
       :class="[style, 'w-full']"


### PR DESCRIPTION
                                                                                                    
  Password managers (1Password, LastPass, Bitwarden, Dashlane) inject icons and popups into form    
  inputs. These are data-annotation forms, not login forms — password manager UI is disruptive and  
  unnecessary here.                      

  ### Changes

  **Form-level** (1Password + Dashlane):
  - Added `autocomplete="off"`, `data-1p-ignore`, `data-form-type="other"` on `<form>` in
  `FormComponent.vue`

  **Input-level** (LastPass + Bitwarden):
  - Added `data-lpignore="true"` and `data-bwignore="true"` on all input elements:
    - `Input.vue`
    - `InputNumber.vue`
    - `Textarea.vue`
    - `AutoComplete.vue`
    - `DateRangeControlRenderer.vue` (both date inputs)

  ### Why vendor-specific attributes?

  Standard `autocomplete="off"` is ignored by most password managers. Each vendor requires its own
  opt-out attribute:

  | Attribute | Vendor | Scope |
  |-----------|--------|-------|
  | `data-1p-ignore` | 1Password | form |
  | `data-form-type="other"` | Dashlane | form |
  | `data-lpignore="true"` | LastPass | input |
  | `data-bwignore="true"` | Bitwarden | input |